### PR TITLE
Fix error after using Blob instead of BlobBuilder.

### DIFF
--- a/blockly/apps/blocklyduino/blockly_helper.js
+++ b/blockly/apps/blocklyduino/blockly_helper.js
@@ -44,7 +44,7 @@ function save() {
   // builder.append(data);
   // saveAs(builder.getBlob('text/plain;charset=utf-8'), 'blockduino.xml');
   console.log("saving blob");
-  var blob = new Blob(data, {type: 'text/xml'});
+  var blob = new Blob([data], {type: 'text/xml'});
   saveAs(blob, 'blockduino.xml');
 }
 


### PR DESCRIPTION
Error was: 'first argument of constructor in not of type array'.
Thanks to an article (search for 'Creating Blobs the new way'):
http://www.nczonline.net/blog/2012/06/05/working-with-files-in-javascript-part-5-blobs/
Now it works for me.
