### PR TITLE
do not remove parentheses inside value parameters

### DIFF
--- a/blockly/generators/arduino/base.js
+++ b/blockly/generators/arduino/base.js
@@ -210,7 +210,6 @@ Blockly.Arduino = Blockly.Generator.get('Arduino');
 
 Blockly.Arduino.base_delay = function() {
   var delay_time = Blockly.Arduino.valueToCode(this, 'DELAY_TIME', Blockly.Arduino.ORDER_ATOMIC) || '1000'
-  delay_time = delay_time.replace('(','').replace(')','');
   var code = 'delay(' + delay_time + ');\n';
   return code;
 };
@@ -218,8 +217,6 @@ Blockly.Arduino.base_delay = function() {
 Blockly.Arduino.base_map = function() {
   var value_num = Blockly.Arduino.valueToCode(this, 'NUM', Blockly.Arduino.ORDER_NONE);
   var value_dmax = Blockly.Arduino.valueToCode(this, 'DMAX', Blockly.Arduino.ORDER_ATOMIC);
-  //value_num = value_num.replace('(','').replace(')','');
-  value_dmax = value_dmax.replace('(','').replace(')','');
   var code = 'map('+value_num+', 0, 1024, 0, '+value_dmax+')';
   return [code, Blockly.Arduino.ORDER_NONE];
 };
@@ -250,7 +247,6 @@ Blockly.Arduino.inout_analog_write = function() {
   var dropdown_pin = this.getTitleValue('PIN');
   //var dropdown_stat = this.getTitleValue('STAT');
   var value_num = Blockly.Arduino.valueToCode(this, 'NUM', Blockly.Arduino.ORDER_ATOMIC);
-  value_num = value_num.replace('(','').replace(')','');
   //Blockly.Arduino.setups_['setup_output'+dropdown_pin] = 'pinMode('+dropdown_pin+', OUTPUT);';
   var code = 'analogWrite('+dropdown_pin+','+value_num+');\n';
   return code;

--- a/blockly/generators/arduino/custom.js
+++ b/blockly/generators/arduino/custom.js
@@ -44,7 +44,6 @@ Blockly.Language.custom_write = {
 Blockly.Arduino.custom_write = function() {
   var dropdown_pin = this.getTitleValue('PIN');
   var value_num = Blockly.Arduino.valueToCode(this, 'NUM', Blockly.Arduino.ORDER_ATOMIC);
-  value_num = value_num.replace('(','').replace(')','');
 
   var code = 'analogWrite('+dropdown_pin+','+value_num+');\n';
   return code;


### PR DESCRIPTION
I came across this bug when I tried to do this:

![screen shot 2014-01-24 at 7 28 37 am](https://f.cloud.github.com/assets/106337/1994704/71a37940-84f4-11e3-91c5-c4b584189b2f.png)

This generated the following code:

```
analogWrite(A0, analogRead(A0 / 4));
```

which is obviously wrong, I do not want to _read_ from the PIN `A0 / 4`, which is nonsensical; I want to read from A0 and divide the result by 4. (err, and in the actual code I was not reading from the same pin I was writing to).

The culprit seems to be removing the parentheses from "value" parameters, which happens in several arduino functions. (The same thing happens in the delay function, for example). Removing these fixes the problem, and I see no reason to remove the parentheses.
