### PR TITLE
Proposing workaround for strong typed variables

### DIFF
--- a/blockly/blocks/variables.js
+++ b/blockly/blocks/variables.js
@@ -43,8 +43,13 @@ Blockly.Blocks['variables_declare'] = {
         .appendField(new Blockly.FieldVariable(
         Blockly.LANG_VARIABLES_SET_ITEM), 'VAR')
         .appendField("as")
-      .appendField(new Blockly.FieldDropdown([["Number", "int"]]), "TYPE")
-      .appendField("value");
+        .appendField(new Blockly.FieldDropdown([
+          ["Number", "int"],
+          ["Float", "float"],
+          ["Double", "double"],
+          ["Char", "char"]
+        ]), "TYPE")
+        .appendField("value");
     this.setPreviousStatement(true);
     this.setNextStatement(true);
     this.setTooltip('');

--- a/blockly/generators/arduino.js
+++ b/blockly/generators/arduino.js
@@ -97,6 +97,8 @@ Blockly.Arduino.init = function(workspace) {
   Blockly.Arduino.definitions_ = Object.create(null);
   // Create a dictionary of setups to be printed before the code.
   Blockly.Arduino.setups_ = Object.create(null);
+  // Create a dictionary of types for variables.
+  Blockly.Arduino.variableTypes_ = Object.create(null);
 
 	if (!Blockly.Arduino.variableDB_) {
 		Blockly.Arduino.variableDB_ =
@@ -134,6 +136,14 @@ Blockly.Arduino.finish = function(code) {
     if (def.match(/^#include/)) {
       imports.push(def);
     } else {
+      if (name === 'variables') {
+        // Replace real types of variables if given, other than the default 'int'.
+        def = def.replace(/int (\w+);/g, function (s, v) {
+          var type = Blockly.Arduino.variableTypes_[v];
+          if (type && type != 'int') return type + ' ' + v + ';';
+          else return s;
+        });
+      }
       definitions.push(def);
     }
   }

--- a/blockly/generators/arduino/variables.js
+++ b/blockly/generators/arduino/variables.js
@@ -38,12 +38,13 @@ Blockly.Arduino.variables_get = function() {
 Blockly.Arduino.variables_declare = function() {
   // Variable setter.
   var dropdown_type = this.getFieldValue('TYPE');
-  //TODO: settype to variable
   var argument0 = Blockly.Arduino.valueToCode(this, 'VALUE',
       Blockly.Arduino.ORDER_ASSIGNMENT) || '0';
   var varName = Blockly.Arduino.variableDB_.getName(this.getFieldValue('VAR'),
       Blockly.Variables.NAME_TYPE);
   Blockly.Arduino.setups_['setup_var' + varName] = varName + ' = ' + argument0 + ';\n';
+  // Set type to variable
+  Blockly.Arduino.variableTypes_[varName] = dropdown_type;
   return '';
 };
 


### PR DESCRIPTION
Hi~

I find that the **Blockly.Arduino.variables_declare** call is between **Blockly.Arduino.init** and **Blockly.Arduino.finish**, so I add a few lines in the 'finish' block to replace types of variables.
Would you please check if this is acceptable or not?
