### PR TITLE
Lcd screen blocks

### DIFF
--- a/blockly/apps/blocklyduino/index.html
+++ b/blockly/apps/blocklyduino/index.html
@@ -401,6 +401,11 @@ function init() {
       </block>
       <block type="servo_read_degrees"></block>
     </category>
+    <category name="LCD Screen">
+      <block type="lcd_setup"></block>
+      <block type="lcd_print"></block>
+      <block type="lcd_clear"></block>
+    </category>
     <category name="Grove Analog">
       <block type="grove_rotary_angle"></block>
       <block type="grove_temporature_sensor"></block>

--- a/blockly/blocks/base.js
+++ b/blockly/blocks/base.js
@@ -253,14 +253,14 @@ Blockly.Blocks['lcd_setup'] = {
 };
 
 Blockly.Blocks['lcd_print'] = {
-  //generates array needed for columns
-  var columns = [];
-  for(int i = 0; i < 16;i++){
-    columns.append([(i + 1).toString(), i.toString()]);
-  }
-
   init: function() {
     this.setColour (257);
+    //generates array needed for columns
+    var columns = [];
+    for(var i = 0; i < 16;i++){
+      columns.push([(i + 1).toString(), i.toString()]);
+    }
+    //
     this.appendDummyInput("")
       .appendField("LCD Print")
       .appendField("Cursor Column #: ")

--- a/blockly/blocks/base.js
+++ b/blockly/blocks/base.js
@@ -227,3 +227,64 @@ Blockly.Blocks['serial_print'] = {
     this.setTooltip('Prints data to the console/serial port as human-readable ASCII text.');
   }
 };
+
+Blockly.Blocks['lcd_setup'] = {
+  init: function() {
+    this.setColour (257);
+    this.appendDummyInput("")
+      .appendField("Setup LCD")
+      .appendField(new Blockly.FieldImage("https://c1.staticflickr.com/9/8305/7804378078_4cca315e83.jpg", 64, 64))
+      .appendField("RS PIN#")
+      .appendField(new Blockly.FieldDropdown(profile.default.digital), "RS_PIN")
+      .appendField("ENABLE PIN#")
+      .appendField(new Blockly.FieldDropdown(profile.default.digital), "ENABLE_PIN")
+      .appendField("D4 PIN#")
+      .appendField(new Blockly.FieldDropdown(profile.default.digital), "D4_PIN")
+      .appendField("D5 PIN#")
+      .appendField(new Blockly.FieldDropdown(profile.default.digital), "D5_PIN")
+      .appendField("D6 PIN#")
+      .appendField(new Blockly.FieldDropdown(profile.default.digital), "D6_PIN")
+      .appendField("D7 PIN#")
+      .appendField(new Blockly.FieldDropdown(profile.default.digital), "D7_PIN");
+  this.setPreviousStatement(true,null);
+  this.setNextStatement(true,null);
+  this.setTooltip('Turns on the LCD');
+  }
+};
+
+Blockly.Blocks['lcd_print'] = {
+  //generates array needed for columns
+  var columns = [];
+  for(int i = 0; i < 16;i++){
+    columns.append([(i + 1).toString(), i.toString()]);
+  }
+
+  init: function() {
+    this.setColour (257);
+    this.appendDummyInput("")
+      .appendField("LCD Print")
+      .appendField("Cursor Column #: ")
+      .appendField(new Blockly.FieldDropdown(columns), "CURSOR_COLUMN#")
+      .appendField("Cursor Row: ")
+      .appendField(new Blockly.FieldDropdown([["First Row","0"], ["Second Row", "1"]]), "CURSOR_ROW#");
+    this.appendValueInput("STRINGOUTPUT", String)
+      .setAlign(Blockly.ALIGN_RIGHT)
+      .appendField("Text:");
+    this.setPreviousStatement(true,null);
+    this.setNextStatement(true,null);
+    this.setTooltip('Prints text to the LCD');
+  }
+};
+
+Blockly.Blocks['lcd_clear'] = {
+  init: function() {
+    this.setColour(257);
+    this.appendDummyInput("")
+      .appendField("LCD Clear")
+    this.setPreviousStatement(true,null);
+    this.setNextStatement(true,null);
+    this.setTooltip('Clears text from the lcd');
+  }
+};
+
+

--- a/blockly/generators/arduino/base.js
+++ b/blockly/generators/arduino/base.js
@@ -153,3 +153,26 @@ Blockly.Arduino.serial_print = function() {
   var code = 'Serial.print(' + content + ');\nSerial.print("\\t");\n';
   return code;
 };
+
+Blockly.Arduino.lcd_setup = function(){
+  var rs_pin = this.getFieldValue('RS_PIN');
+  var enable_pin = this.getFieldValue('ENABLE_PIN');
+  var d4_pin = this.getFieldValue('D4_PIN');
+  var d5_pin = this.getFieldValue('D5_PIN');
+  var d6_pin = this.getFieldValue('D6_PIN');
+  var d7_pin = this.getFieldValue('D7_PIN');
+  var col_num = '16'
+  var row_num = '2';
+
+  Blockly.Arduino.definitions_['define_liquidcrystal'] =  '#include <LiquidCrystal.h>\n';
+  Blockly.Arduino.definitions_['var_lcd'] = 'LiquidCrystal lcd('+rs_pin+','+enable_pin+','+d4_pin+','+d5_pin+','+d6_pin+','+d7_pin+');\n';
+  Blockly.Arduino.setups_['setup_lcd'] =  'lcd.begin('+col_num+', '+row_num+');\n';
+  
+  var code = '';
+  return code;
+};
+
+Blockly.Arduino.lcd_clear = function(){
+  var code = 'lcd.clear();\n';
+  return code;
+};

--- a/blockly/generators/arduino/base.js
+++ b/blockly/generators/arduino/base.js
@@ -172,6 +172,15 @@ Blockly.Arduino.lcd_setup = function(){
   return code;
 };
 
+Blockly.Arduino['lcd_print'] = function(block){
+  var curs_col = this.getFieldValue('CURSOR_COLUMN#') || '0';
+  var curs_row = this.getFieldValue('CURSOR_ROW#') || '0';
+  var output = Blockly.Arduino.valueToCode(this, 'STRINGOUTPUT', Blockly.Arduino.ORDER_UNARY_POSTFIX) || 'null';
+  
+  var code = 'lcd.setCursor('+curs_col+', '+curs_row+');\nlcd.print('+output+');\n';
+  return code;
+};
+
 Blockly.Arduino.lcd_clear = function(){
   var code = 'lcd.clear();\n';
   return code;


### PR DESCRIPTION
Adds three new blocks to be used with common LCD's included in most beginners kits. Blocks includes LCD setup, LCD print, and LCD clear.
