### PR TITLE
Modify the build script to specify ECMASCRIPT5 as the language to the closure compiler

### DIFF
--- a/blockly/build.py
+++ b/blockly/build.py
@@ -244,6 +244,7 @@ class Gen_compressed(threading.Thread):
 
   def do_compile(self, params, target_filename, filenames, remove):
     # Send the request to Google.
+    params.append(("language", "ECMASCRIPT5"))
     headers = {"Content-type": "application/x-www-form-urlencoded"}
     conn = httplib.HTTPConnection("closure-compiler.appspot.com")
     conn.request("POST", "/compile", urllib.urlencode(params), headers)


### PR DESCRIPTION
This removes the warnings about using 'default' as a token in BlocklyDuino.
