### PR TITLE
fixes #20: always use latest workspace to upload code to board

### DIFF
--- a/blockly/apps/blocklyduino/blockly_helper.js
+++ b/blockly/apps/blocklyduino/blockly_helper.js
@@ -248,7 +248,7 @@ function uploadCode(code, callback) {
 }
 
 function uploadClick() {
-    var code = document.getElementById('content_arduino').value;
+    var code = Blockly.Arduino.workspaceToCode();
 
     alert("Ready to upload to Arduino.");
     


### PR DESCRIPTION
just changed one line to make it possible to upload faster after changing boxes in workspace without having to check the Arduino tab
