### PR TITLE
Added Arduino_debug

### DIFF
--- a/arduino_web_server.py
+++ b/arduino_web_server.py
@@ -29,7 +29,9 @@ def get_arduino_command():
             arduino_cmd_guesses = ["/Applications/Arduino.app/Contents/MacOS/Arduino"]
         elif platform.system() == "Windows":
             arduino_cmd_guesses = [
+                "c:\Program Files\Arduino\Arduino_debug.exe",
                 "c:\Program Files\Arduino\Arduino.exe",
+                "c:\Program Files (x86)\Arduino\Arduino_debug.exe",
                 "c:\Program Files (x86)\Arduino\Arduino.exe"
             ]
         else:


### PR DESCRIPTION
Arduino.exe gives no feedback to the console, it is better to use Arduino_debug.exe (when available) on Windows.

https://github.com/arduino/Arduino/blob/master/build/shared/manpage.adoc#description
