### PR TITLE
Use HTTPS instead of HTTP in build.py

### DIFF
--- a/blockly/build.py
+++ b/blockly/build.py
@@ -246,7 +246,7 @@ class Gen_compressed(threading.Thread):
     # Send the request to Google.
     params.append(("language", "ECMASCRIPT5"))
     headers = {"Content-type": "application/x-www-form-urlencoded"}
-    conn = httplib.HTTPConnection("closure-compiler.appspot.com")
+    conn = httplib.HTTPSConnection("closure-compiler.appspot.com")
     conn.request("POST", "/compile", urllib.urlencode(params), headers)
     response = conn.getresponse()
     json_str = response.read()


### PR DESCRIPTION
https://groups.google.com/forum/#!topic/blockly/EDxPuJQ37RI

Closure compiler no longer accepts HTTP requests, as of last Thursday. It is now HTTPS only.

We've fixed it on Blockly (and always recommend pulling from master to stay up to date) but this is the fastest fix for your repo.

At least one BlocklyDuino user has noticed: https://stackoverflow.com/questions/47057829/occur-error-in-compile-build-py-in-blocklyduino/47143150#47143150